### PR TITLE
Bump commons-io from 2.4 to 2.7 in /CoreJavaProjects/CoreJavaExamples

### DIFF
--- a/CoreJavaProjects/CoreJavaExamples/pom.xml
+++ b/CoreJavaProjects/CoreJavaExamples/pom.xml
@@ -10,7 +10,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.4</version>
+			<version>2.7</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-net</groupId>


### PR DESCRIPTION
Bumps commons-io from 2.4 to 2.7.

Signed-off-by: dependabot[bot] <support@github.com>